### PR TITLE
fix sameMembers function

### DIFF
--- a/test/HelperContract.sol
+++ b/test/HelperContract.sol
@@ -106,12 +106,12 @@ abstract contract HelperContract is IDiamond, IDiamondLoupe, Test{
             return false;
         }
         for (uint i = 0; i < array1.length; i++) {
-            if (containsElement(array1, array2[i])){
-                return true;
+            if (!containsElement(array1, array2[i])){
+                return false;
             }
         }
 
-        return false;
+        return true;
     }
 
     function getAllSelectors(address diamondAddress) public view returns (bytes4[] memory){


### PR DESCRIPTION
The loop in `sameMembers` did not do what it was supposed to. 

It returned true if it found any member of arr2 in arr1 instead of returning true only if all members were found.